### PR TITLE
fix: Move Walt Disney Animation Studios to Short Films section

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,8 +681,6 @@ That's all, I'll be removing all my personal comments from the list, except the 
 
 [**Vogue**](https://www.youtube.com/@vogue) ("73 Questions" series and other fashion/celebrity content)
 
-[**Walt Disney Animation Studios**](https://www.youtube.com/@disneyanimation/) (Trailers, Featurettes, Clips, Songs and shorts like ["Once Upon a Studio"](https://www.youtube.com/watch?v=gB90me0aqSY) )
-
 [**Walt Disney Imagineering**](https://www.youtube.com/@waltdisneyimagineering/featured) (BTS Videos of Disney's parks/ [Inside look at Walt Disney Imagineering](https://www.youtube.com/playlist?list=PLZuKWjoQGMP5LFHVnDn-sxggnJCZi3d9H))
 
 [**Warner Bros Entertainment**](https://www.youtube.com/@warnerbrosentertainment)
@@ -1222,6 +1220,8 @@ That's all, I'll be removing all my personal comments from the list, except the 
 [**Vimeo Staff Picks**](https://www.youtube.com/@VimeoStaffPicks) (A curated collection of top short films from Vimeo)
 
 [**We Are The People**](https://www.youtube.com/@WeAreThePeople) (A platform for diverse and socially conscious short films)
+
+[**Walt Disney Animation Studios**](https://www.youtube.com/@disneyanimation/) (Trailers, Featurettes, Clips, Songs and animated shorts like ["Once Upon a Studio"](https://www.youtube.com/watch?v=gB90me0aqSY))
 
 [**Z-shorts**](https://www.youtube.com/@Z-shorts) (Independent animated shorts)
 


### PR DESCRIPTION
This PR resolves issue by moving Walt Disney Animation Studios from the Misc/Channels section to the Short Films category, since the channel focuses on animated shorts like Once Upon a Studio. The description has been updated to reflect this content more accurately, and this change helps consolidate all short film–related channels into one organized section. It improves clarity, keeps formatting consistent, and makes it easier for users to discover official short film content on YouTube.