### PR TITLE
Adding channel link for The Loud House

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Also a big thanks to [all the members of the FMHY Discord server](https://github
 
 [**The Fairly OddParents**](https://www.youtube.com/@TheFairlyOddParentsOfficial) (Clips, shorts, and full episodes from the Nickelodeon series)
 
+[**The Loud House**](https://www.youtube.com/@LoudHouse) (Official clips, compilations and full episodes)
+
 [**The Powerpuff Girls**](https://www.youtube.com/@ThePowerpuffGirls) (Clips and compilations)
 
 [**The Smurfs**](https://www.youtube.com/@TheSmurfsEnglish) (Official clips, compilations and full episodes)


### PR DESCRIPTION
Added a channel link for the 2016 Nickelodeon animated series The Loud House which houses official clips, compilations and some full episodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new cartoon title to the reference list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->